### PR TITLE
Filelist handling updated and unit-tests added

### DIFF
--- a/dimspy/__main__.py
+++ b/dimspy/__main__.py
@@ -538,7 +538,7 @@ def main():  # pragma: no cover
                     m_nm = pls_merged[i][0].metadata['multilist']
                     hdf5_portal.save_peaklists_as_hdf5(pls_merged[i],
                                                        os.path.join(args.output,
-                                                                    'merged_peaklist_{:03d}.hdf5'.format(int(m_nm))))
+                                                                    'merged_peaklist_{:03d}.hdf5'.format(m_nm)))
         else:
             hdf5_portal.save_peaklists_as_hdf5(pls_merged, args.output)
 

--- a/dimspy/__main__.py
+++ b/dimspy/__main__.py
@@ -538,7 +538,7 @@ def main():  # pragma: no cover
                     m_nm = pls_merged[i][0].metadata['multilist']
                     hdf5_portal.save_peaklists_as_hdf5(pls_merged[i],
                                                        os.path.join(args.output,
-                                                                    'merged_peaklist_{:03}.hdf5'.format(m_nm)))
+                                                                    'merged_peaklist_{:03d}.hdf5'.format(int(m_nm))))
         else:
             hdf5_portal.save_peaklists_as_hdf5(pls_merged, args.output)
 

--- a/dimspy/metadata.py
+++ b/dimspy/metadata.py
@@ -172,6 +172,12 @@ def interpret_method(mzrs: list):
 
     return method
 
+def is_int(x):
+    try:
+        int(x)
+        return True
+    except ValueError as e:
+        return False
 
 def validate_metadata(fn_tsv: str) -> collections.OrderedDict:
     """
@@ -234,6 +240,12 @@ def validate_metadata(fn_tsv: str) -> collections.OrderedDict:
         print("Classes:", cls)
     else:
         warnings.warn("Column 'classLabel' for class labels missing. Not required.")
+
+    if "multilist" in fm_dict:
+        for x in fm_dict['multilist']:
+            assert is_int(x), "Column 'multilist' values should be integers"
+    else:
+        warnings.warn("Column 'multilist' for spliting peaklists is missing. Not required.")
 
     return fm_dict
 

--- a/dimspy/metadata.py
+++ b/dimspy/metadata.py
@@ -202,7 +202,7 @@ def validate_metadata(fn_tsv: str) -> collections.OrderedDict:
 
     if "replicate" in fm_dict.keys():
 
-        if 0 in fm_dict["replicate"]:
+        if "0" in fm_dict["replicate"]:
             raise IOError("Incorrect replicate number in list. Row {}".format(list(fm_dict["replicate"]).index(0)))
 
         idxs_replicates = idxs_reps_from_filelist(fm_dict["replicate"])
@@ -245,7 +245,7 @@ def validate_metadata(fn_tsv: str) -> collections.OrderedDict:
         for x in fm_dict['multilist']:
             assert is_int(x), "Column 'multilist' values should be integers"
     else:
-        warnings.warn("Column 'multilist' for spliting peaklists is missing. Not required.")
+        print("Column 'multilist' for spliting peaklists is missing. Not required.")
 
     return fm_dict
 

--- a/tests/data/MTBLS79_subset/filelist_class_label_error.txt
+++ b/tests/data/MTBLS79_subset/filelist_class_label_error.txt
@@ -1,0 +1,10 @@
+filename	replicate	batch	injectionOrder	classLabel
+batch04_B02_rep01_301.mzML	1	1	1	blank
+batch04_B02_rep02_302.mzML	2	1	2	blank
+batch04_B02_rep03_303.mzML	3	1	3	blank
+batch04_QC17_rep01_262.mzML	4	1	4	QC
+batch04_QC17_rep02_263.mzML	1	1	5	QC
+batch04_QC17_rep03_264.mzML	2	1	6	QC
+batch04_S01_rep01_247.mzML	3	1	7	sample
+batch04_S01_rep02_248.mzML	1	1	8	sample
+batch04_S01_rep03_249.mzML	2	1	9	sample

--- a/tests/data/MTBLS79_subset/filelist_filename_error.txt
+++ b/tests/data/MTBLS79_subset/filelist_filename_error.txt
@@ -1,0 +1,10 @@
+filename	replicate	batch	injectionOrder	classLabel
+batch04_B02_rep01_301.mzML	1	1	1	blank
+batch04_B02_rep02_302.mzML	2	1	2	blank
+batch04_B02_rep03_303.mzML	3	1	3	blank
+batch04_QC17_rep01_262.mzML	1	1	4	QC
+batch04_QC17_rep02_263.mzML	2	1	5	QC
+batch04_QC17_rep03_264.mzML	3	1	6	QC
+batch04_S01_rep01_247.mzML	1	1	7	sample
+batch04_S01_rep02_248.mzML	2	1	8	sample
+batch04_S01_rep02_248.mzML	3	1	9	sample

--- a/tests/data/MTBLS79_subset/filelist_injection_order_error.txt
+++ b/tests/data/MTBLS79_subset/filelist_injection_order_error.txt
@@ -1,0 +1,10 @@
+filename	replicate	batch	injectionOrder	classLabel
+batch04_B02_rep01_301.mzML	1	1	1	blank
+batch04_B02_rep02_302.mzML	2	1	2	blank
+batch04_B02_rep03_303.mzML	3	1	3	blank
+batch04_QC17_rep01_262.mzML	1	1	10	QC
+batch04_QC17_rep02_263.mzML	2	1	5	QC
+batch04_QC17_rep03_264.mzML	3	1	6	QC
+batch04_S01_rep01_247.mzML	1	1	7	sample
+batch04_S01_rep02_248.mzML	2	1	8	sample
+batch04_S01_rep03_249.mzML	3	1	4	sample

--- a/tests/data/MTBLS79_subset/filelist_multi_error.txt
+++ b/tests/data/MTBLS79_subset/filelist_multi_error.txt
@@ -1,0 +1,4 @@
+filename	class	multilist
+batch04_QC17_rep01_262.RAW	blank	1
+batch04_QC17_rep02_263.RAW	sample	'UNWANTED STRING'
+batch04_QC17_rep03_264.RAW	sample	2

--- a/tests/data/MTBLS79_subset/filelist_replicate_error_1.txt
+++ b/tests/data/MTBLS79_subset/filelist_replicate_error_1.txt
@@ -1,0 +1,10 @@
+filename	replicate	batch	injectionOrder	classLabel
+batch04_B02_rep01_301.mzML	1	1	1	blank
+batch04_B02_rep02_302.mzML	2	1	2	blank
+batch04_B02_rep03_303.mzML	0	1	3	blank
+batch04_QC17_rep01_262.mzML	1	1	4	QC
+batch04_QC17_rep02_263.mzML	2	1	5	QC
+batch04_QC17_rep03_264.mzML	0	1	6	QC
+batch04_S01_rep01_247.mzML	1	1	7	sample
+batch04_S01_rep02_248.mzML	2	1	8	sample
+batch04_S01_rep03_249.mzML	0	1	9	sample

--- a/tests/data/MTBLS79_subset/filelist_replicate_error_2.txt
+++ b/tests/data/MTBLS79_subset/filelist_replicate_error_2.txt
@@ -1,0 +1,10 @@
+filename	replicate	batch	injectionOrder	classLabel
+batch04_B02_rep01_301.mzML	1	1	1	blank
+batch04_B02_rep02_302.mzML	2	1	2	blank
+batch04_B02_rep03_303.mzML	3	1	3	blank
+batch04_QC17_rep01_262.mzML	1	1	4	QC
+batch04_QC17_rep02_263.mzML	2	1	5	QC
+batch04_QC17_rep03_264.mzML	10	1	6	QC
+batch04_S01_rep01_247.mzML	1	1	7	sample
+batch04_S01_rep02_248.mzML	5	1	8	sample
+batch04_S01_rep03_249.mzML	3	1	9	sample

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -29,15 +29,15 @@ class ValidateMetadataTestCase(unittest.TestCase):
                                                'batch04_QC17_rep02_263.mzML', 'batch04_QC17_rep03_264.mzML',
                                                'batch04_S01_rep01_247.mzML', 'batch04_S01_rep02_248.mzML',
                                                'batch04_S01_rep03_249.mzML'])
-        self.assertEqual(fm_dict['replicate'], ['1', '2', '3', '1', '2', '3', '1', '2', '3'])
-        self.assertEqual(fm_dict['batch'], ['1'] * 9)
-        self.assertEqual(fm_dict['injectionOrder'], ['1', '2', '3', '4', '5', '6', '7', '8', '9'])
+        self.assertEqual(fm_dict['replicate'], [1, 2, 3, 1, 2, 3, 1, 2, 3])
+        self.assertEqual(fm_dict['batch'], [1] * 9)
+        self.assertEqual(fm_dict['injectionOrder'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(fm_dict['classLabel'], ['blank', 'blank', 'blank',
                                                  'QC', 'QC', 'QC', 'sample', 'sample', 'sample'])
 
     def test_filelist_multi(self):
         fm_dict = validate_metadata(to_test_data("filelist_multi.txt"))
-        self.assertEqual(fm_dict['multilist'], ['1', '1', '2'])
+        self.assertEqual(fm_dict['multilist'], [1, 1, 2])
 
     def test_filename_error(self):
         with self.assertRaises(Exception) as context:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+
+"""
+test_metadata
+
+author(s): Albert, Ralf, Tom
+origin: 29-10-2019
+
+"""
+
+import unittest
+import os
+
+from dimspy.metadata import validate_metadata
+
+
+def to_test_data(*args):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "MTBLS79_subset", *args)
+
+
+class ValidateMetadataTestCase(unittest.TestCase):
+
+    def test_filelist_standard(self):
+        # filename	replicate	batch	injectionOrder	classLabel
+        fm_dict = validate_metadata(to_test_data("filelist_csl_MTBLS79_mzml_triplicates.txt"))
+        self.assertEqual(fm_dict['filename'], ['batch04_B02_rep01_301.mzML', 'batch04_B02_rep02_302.mzML',
+                                               'batch04_B02_rep03_303.mzML', 'batch04_QC17_rep01_262.mzML',
+                                               'batch04_QC17_rep02_263.mzML', 'batch04_QC17_rep03_264.mzML',
+                                               'batch04_S01_rep01_247.mzML', 'batch04_S01_rep02_248.mzML',
+                                               'batch04_S01_rep03_249.mzML'])
+        self.assertEqual(fm_dict['replicate'], ['1', '2', '3', '1', '2', '3', '1', '2', '3'])
+        self.assertEqual(fm_dict['batch'], ['1'] * 9)
+        self.assertEqual(fm_dict['injectionOrder'], ['1', '2', '3', '4', '5', '6', '7', '8', '9'])
+        self.assertEqual(fm_dict['classLabel'], ['blank', 'blank', 'blank',
+                                                 'QC', 'QC', 'QC', 'sample', 'sample', 'sample'])
+
+    def test_filelist_multi(self):
+        fm_dict = validate_metadata(to_test_data("filelist_multi.txt"))
+        self.assertEqual(fm_dict['multilist'], ['1', '1', '2'])
+
+    def test_filename_error(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_filename_error.txt"))
+        self.assertTrue("Duplicate filename in list" in str(context.exception))
+
+    def test_filelist_multilist_error(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_multi_error.txt"))
+        self.assertTrue("Column 'multilist' values should be integers" in str(context.exception))
+
+    def test_filelist_injection_order_error(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_injection_order_error.txt"))
+        self.assertTrue("samples not in order" in str(context.exception))
+
+    def test_filelist_class_label_error(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_class_label_error.txt"))
+        self.assertTrue("class names do not match with number of replicates" in str(context.exception))
+
+    def test_filelist_replicate_error_zero_value(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_replicate_error_1.txt"))
+        self.assertTrue("Incorrect replicate number in list" in str(context.exception))
+
+    def test_filelist_replicate_error_zero_value(self):
+        with self.assertRaises(Exception) as context:
+            validate_metadata(to_test_data("filelist_replicate_error_2.txt"))
+        self.assertTrue("Incorrect numbering for replicates" in str(context.exception))
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Update filelist handling to convert relevant columns from string to int ('replicate', 'batch', 'injectionOrder' and 'multilist')
* Added unit tests for the validate_filelist function